### PR TITLE
Reduce required PHP version to 7.4 again

### DIFF
--- a/biscotti.php
+++ b/biscotti.php
@@ -17,7 +17,7 @@
  * Description:       Biscotti makes your user's login cookie a little bit longer.
  * Version:           2.1.0
  * Requires at least: 6.0
- * Requires PHP:      8.0
+ * Requires PHP:      7.4
  * Author:            Jason Cosper
  * Author URI:        https://jasoncosper.com/
  * License:           GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: login, cookies, profile, login
 Requires at least: 6.0
 Tested up to: 6.2
 Stable tag: 2.1.0
-Requires PHP: 8.0
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
 


### PR DESCRIPTION
In [2.1.0](https://github.com/boogah/biscotti/releases/tag/v2.1.0) the required PHP version was increased to 8.0, was there a particular reason for that except that PHP 7.4 is EOL? It still parses fine. If no, can we reduce it again?

❯ php -v
PHP 7.4.33 (cli) (built: Jun 17 2023 06:19:58) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.33, Copyright (c), by Zend Technologies
    with Xdebug v3.1.3, Copyright (c) 2002-2022, by Derick Rethans
❯ php -l biscotti.php
No syntax errors detected in biscotti.php
